### PR TITLE
May 16th

### DIFF
--- a/allegro initialize.cpp
+++ b/allegro initialize.cpp
@@ -56,6 +56,12 @@ int main_innitialize() {
         return -1;
     }
 
+    if (!al_init_primitives_addon()) {
+    	al_show_native_message_box(display, "Error", "Error", "Failed to initialize primatives addon!",
+                                 nullptr, ALLEGRO_MESSAGEBOX_ERROR);
+    	return -1;
+	}
+
 
     al_register_event_source(event_queue, al_get_display_event_source(display));
  	al_register_event_source(event_queue, al_get_keyboard_event_source());

--- a/functions initialize.cpp
+++ b/functions initialize.cpp
@@ -8,36 +8,35 @@
 
 extern ALLEGRO_DISPLAY *display;
 extern ALLEGRO_BITMAP *background;
-extern Image *spaceship;
-extern ALLEGRO_BITMAP *astronaut[12];
-extern ALLEGRO_BITMAP *hatch;
+extern Image spaceship;
+extern Image astronaut[12];
+extern Image hatch;
 extern ALLEGRO_EVENT_QUEUE *event_queue;
 extern ALLEGRO_EVENT event;
 extern ALLEGRO_TIMER *timer;
+
 
 void calcBounds(Image &a) {
     a.bbLeft = a.x;
 	a.bbTop  = a.y;
 	a.bbRight = a.bbLeft + al_get_bitmap_width(a.bitmap);
 	a.bbBottom = a.bbTop + al_get_bitmap_height(a.bitmap);
+
 }
 
 void draw_background(){
     al_draw_scaled_bitmap(background,0,0,1300,1300,0,0,1380,1000,0);
 }
 
-void draw_spaceship(Image &a){
+void draw_image(Image &a){
     al_draw_bitmap(a.bitmap, a.x, a.y, 0);
 }
 
-void draw_hatch(){
-    al_draw_scaled_bitmap(hatch,0,0,300,300,500,250,50,50,0);
+void draw_astronaut(Image astronaut[], int frame, int direction){
+    frame += direction*3;
+    al_draw_bitmap(astronaut[frame].bitmap,astronaut[frame].x,astronaut[frame].y,0);
 }
 
-void draw_astronaut(Image astronaut[], int posX, int posY, int frame, int direction){
-    frame += direction*3;
-    al_draw_scaled_bitmap(astronaut[frame].bitmap,0,0,95,115,posX,posY,58,69,0);
-}
 
 bool check_in_bounds(int &posX, int &posY){
 
@@ -59,3 +58,28 @@ bool check_in_bounds(int &posX, int &posY){
 
         return false;
 }
+
+bool isCollision(Image a, Image b) {
+    if (a.bbBottom < b.bbTop) {
+        return false;
+    }
+    else if (a.bbTop > b.bbBottom) {
+        return false;
+    }
+    else if (a.bbRight < b.bbLeft) {
+        return false;
+    }
+    else if (a.bbLeft > b.bbRight) {
+        return false;
+    }
+    return true;
+}
+
+void drawBoundingBox(Image image) {
+    calcBounds(image);
+	al_draw_line(image.bbLeft, image.bbTop, image.bbRight, image.bbTop, WHITE, 1);
+    al_draw_line(image.bbLeft, image.bbBottom, image.bbRight, image.bbBottom, WHITE, 1);
+	al_draw_line(image.bbLeft, image.bbTop, image.bbLeft, image.bbBottom, WHITE, 1);
+	al_draw_line(image.bbRight, image.bbTop, image.bbRight, image.bbBottom, WHITE,1);
+}
+

--- a/images initialize.cpp
+++ b/images initialize.cpp
@@ -5,12 +5,12 @@
 #include "setup.h"
 #include <stdio.h>
 
-#define WHITE al_map_rgb(255,255,255)
+
 extern ALLEGRO_DISPLAY *display;
 extern ALLEGRO_BITMAP *background;
 extern Image spaceship;
 extern Image astronaut[12];
-extern ALLEGRO_BITMAP *hatch;
+extern Image hatch;
 
 void calcBounds(Image &a);
 
@@ -48,6 +48,7 @@ int images_innitialize() {
 
     astronaut[1].bitmap  = al_load_bitmap("Images/astronaut_front_2.png");
     al_convert_mask_to_alpha(astronaut[1].bitmap , WHITE);
+    calcBounds(astronaut[1]);
     if (!astronaut[1].bitmap ) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_front_2)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -57,6 +58,7 @@ int images_innitialize() {
 
     astronaut[2].bitmap = al_load_bitmap("Images/astronaut_front_3.png");
     al_convert_mask_to_alpha(astronaut[2].bitmap , WHITE);
+    calcBounds(astronaut[2]);
     if (!astronaut[2].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_front_3)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -66,6 +68,7 @@ int images_innitialize() {
 
     astronaut[3].bitmap = al_load_bitmap("Images/astronaut_left_1.png");
     al_convert_mask_to_alpha(astronaut[3].bitmap, WHITE);
+    calcBounds(astronaut[3]);
     if (!astronaut[3].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_left_1)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -75,6 +78,7 @@ int images_innitialize() {
 
     astronaut[4].bitmap = al_load_bitmap("Images/astronaut_left_2.png");
     al_convert_mask_to_alpha(astronaut[4].bitmap, WHITE);
+    calcBounds(astronaut[4]);
     if (!astronaut[4].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_left_2)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -85,6 +89,7 @@ int images_innitialize() {
 
     astronaut[5].bitmap = al_load_bitmap("Images/astronaut_left_3.png");
     al_convert_mask_to_alpha(astronaut[5].bitmap, WHITE);
+    calcBounds(astronaut[5]);
     if (!astronaut[5].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_left_3)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -94,6 +99,7 @@ int images_innitialize() {
 
     astronaut[6].bitmap = al_load_bitmap("Images/astronaut_back_1.png");
     al_convert_mask_to_alpha(astronaut[6].bitmap, WHITE);
+    calcBounds(astronaut[6]);
     if (!astronaut[6].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_back_1)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -103,6 +109,7 @@ int images_innitialize() {
 
     astronaut[7].bitmap = al_load_bitmap("Images/astronaut_back_2.png");
     al_convert_mask_to_alpha(astronaut[7].bitmap, WHITE);
+    calcBounds(astronaut[7]);
     if (!astronaut[7].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_back_2)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -112,6 +119,7 @@ int images_innitialize() {
 
     astronaut[8].bitmap = al_load_bitmap("Images/astronaut_back_3.png");
     al_convert_mask_to_alpha(astronaut[8].bitmap, WHITE);
+    calcBounds(astronaut[8]);
     if (!astronaut[8].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_back_3)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -121,6 +129,7 @@ int images_innitialize() {
 
     astronaut[9].bitmap = al_load_bitmap("Images/astronaut_right_1.png");
     al_convert_mask_to_alpha(astronaut[9].bitmap, WHITE);
+    calcBounds(astronaut[9]);
     if (!astronaut[9].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_right_1)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -130,6 +139,7 @@ int images_innitialize() {
 
     astronaut[10].bitmap = al_load_bitmap("Images/astronaut_right_2.png");
     al_convert_mask_to_alpha(astronaut[10].bitmap, WHITE);
+    calcBounds(astronaut[10]);
     if (!astronaut[10].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_left_2)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -139,6 +149,7 @@ int images_innitialize() {
 
     astronaut[11].bitmap = al_load_bitmap("Images/astronaut_right_3.png");
     al_convert_mask_to_alpha(astronaut[11].bitmap, WHITE);
+    calcBounds(astronaut[11]);
     if (!astronaut[11].bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (astronaut_left_3)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
@@ -146,9 +157,12 @@ int images_innitialize() {
      	return -1;
     }
 
-    hatch = al_load_bitmap("Images/hatch panel.jpeg");
-    al_convert_mask_to_alpha(hatch, WHITE);
-    if (!hatch) {
+    hatch.bitmap = al_load_bitmap("Images/hatch panel.png");
+    al_convert_mask_to_alpha(hatch.bitmap, WHITE);
+    hatch.x = 500;
+    hatch.y = 300;
+    calcBounds(hatch);
+    if (!hatch.bitmap) {
 		al_show_native_message_box(display, "Error", "Error", "Failed to load image (hatch)!",
                                  nullptr, ALLEGRO_MESSAGEBOX_ERROR);
       	al_destroy_display(display);

--- a/setup.h
+++ b/setup.h
@@ -6,6 +6,8 @@ struct Image {
     int bbRight, bbLeft, bbTop, bbBottom; // boundary box
 };
 
+#define WHITE al_map_rgb(255,255,255)
+
 #ifdef SETUP_H_INCLUDED
 
 #endif // SETUP_H_INCLUDED


### PR DESCRIPTION
Thursday May 16th: 

- Fixed bugs for drawing boundary boxes. The al_draw_line function wasn’t working because the Allegro primitive library hadn’t been set up properly. (allegro initialize.cpp lines 59-64)
- Changed size of astronaut graphics to make boundary box the right size. Made the astronaut be drawn as a normal bitmap instead of being scaled. The boundary box was being drawn based on dimensions pre-scaling (functions initialize.cpp, line 31)
- Added boolean for whether or not a hatch has been picked up. (main.cpp, line 33)
- Added logic to pick up/drop hatch panels and put them on the rocket using collision detection and keyboard events (Space bar to pick up/drop/place). (main.cpp, lines 100-109, 131-134)
